### PR TITLE
Fix compile warnings in Elixir 1.11+

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule GelfLogger.Mixfile do
   def project do
     [app: :gelf_logger,
      version: "0.8.0",
-     elixir: "~> 1.2",
+     elixir: "~> 1.4",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
      deps: deps(),
@@ -25,7 +25,7 @@ defmodule GelfLogger.Mixfile do
   #
   # Type "mix help compile.app" for more information
   def application do
-    [applications: [:logger]]
+    [extra_applications: [:crypto, :logger]]
   end
 
   defp deps do


### PR DESCRIPTION
Compiling `gelf_logger` in Elixir 1.11+ produces the following warning:
```
==> gelf_logger
Compiling 1 file (.ex)
warning: :crypto.strong_rand_bytes/1 defined in application :crypto is used by the current application but the current application does not depend on :crypto. To fix this, you must do one of:

  1. If :crypto is part of Erlang/Elixir, you must include it under :extra_applications inside "def application" in your mix.exs

  2. If :crypto is a dependency, make sure it is listed under "def deps" in your mix.exs

  3. In case you don't want to add a requirement to :crypto, you may optionally skip this warning by adding [xref: [exclude: [:crypto]]] to your "def project" in mix.exs

  lib/gelf_logger.ex:244: Logger.Backends.Gelf.log_event/5

Generated gelf_logger app
```